### PR TITLE
Enable running a local mirror of the PLC registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.sqlite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +103,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+
+[[package]]
+name = "async-sqlite"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e420455ac3543544cbf17c36ff308807a6e62d7952e965c749dab53d860870c"
+dependencies = [
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-util",
+ "rusqlite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +139,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atrium-api"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51be636518e52db487131b481b939f8a01d8a02e85fe9eea77aab5429ace3840"
+checksum = "3cddf32d315784f77935e5433327433a05da76513ceb4c14e6be6ac0d243a02f"
 dependencies = [
  "async-trait",
  "atrium-xrpc",
@@ -398,6 +428,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +611,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +702,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -732,6 +801,18 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -1063,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1164,17 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1121,6 +1219,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -1199,6 +1306,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -1333,6 +1450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1548,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 name = "plc"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "async-sqlite",
  "atrium-api",
  "atrium-crypto",
  "atrium-xrpc",
@@ -1446,6 +1571,8 @@ dependencies = [
  "sha2",
  "snapbox",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "xdg",
  "zeroize",
 ]
@@ -1539,8 +1666,17 @@ checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1551,8 +1687,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1636,6 +1778,21 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "serde_json",
+ "smallvec",
 ]
 
 [[package]]
@@ -1854,10 +2011,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -2041,6 +2216,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2251,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -2172,6 +2358,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2241,6 +2457,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1011,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1228,6 +1290,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1554,8 +1622,10 @@ dependencies = [
  "atrium-crypto",
  "atrium-xrpc",
  "atrium-xrpc-client",
+ "axum",
  "base32",
  "base64ct",
+ "bytes",
  "chrono",
  "cid",
  "clap",
@@ -1563,9 +1633,11 @@ dependencies = [
  "hex",
  "hickory-resolver",
  "known-folders",
+ "mime",
  "rand_core",
  "reqwest",
  "serde",
+ "serde-jsonlines",
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2",
@@ -1733,7 +1805,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1855,6 +1927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +2009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-jsonlines"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bdd6db666f827c1843d4710520093675e6c0b6e39a02e1a8d9e9b2f71cbb58"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2072,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2154,6 +2252,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -2315,6 +2419,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2335,6 +2440,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "cid",
  "clap",
  "diff-struct",
+ "futures-util",
  "hex",
  "hickory-resolver",
  "known-folders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ anyhow = { version = "1", optional = true }
 async-sqlite = { version = "0.3", optional = true, features = ["serde_json"] }
 axum = { version = "0.7", optional = true }
 bytes = { version = "1", optional = true }
+futures-util = { version = "0.3", optional = true }
 mime = { version = "0.3", optional = true }
 serde-jsonlines = { version = "0.6", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -59,6 +60,7 @@ mirror = [
     "dep:async-sqlite",
     "dep:axum",
     "dep:bytes",
+    "dep:futures-util",
     "dep:mime",
     "dep:serde-jsonlines",
     "dep:tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ xdg = "2"
 # Registry mirror
 anyhow = { version = "1", optional = true }
 async-sqlite = { version = "0.3", optional = true, features = ["serde_json"] }
+axum = { version = "0.7", optional = true }
+bytes = { version = "1", optional = true }
+mime = { version = "0.3", optional = true }
+serde-jsonlines = { version = "0.6", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt"]}
 
@@ -53,6 +57,10 @@ snapbox = { version = "0.6", features = ["dir"] }
 mirror = [
     "dep:anyhow",
     "dep:async-sqlite",
+    "dep:axum",
+    "dep:bytes",
+    "dep:mime",
+    "dep:serde-jsonlines",
     "dep:tracing",
     "dep:tracing-subscriber",
     "tokio/signal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }
 
 # ATProto
-atrium-api = "0.24"
+atrium-api = "0.24.4"
 atrium-crypto = "0.1"
 atrium-xrpc = "0.11"
 atrium-xrpc-client = "0.5"
@@ -39,9 +39,24 @@ known-folders = "1"
 serde_json = "1"
 xdg = "2"
 
+# Registry mirror
+anyhow = { version = "1", optional = true }
+async-sqlite = { version = "0.3", optional = true, features = ["serde_json"] }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt"]}
+
 [dev-dependencies]
 rand_core = "0.6"
 snapbox = { version = "0.6", features = ["dir"] }
+
+[features]
+mirror = [
+    "dep:anyhow",
+    "dep:async-sqlite",
+    "dep:tracing",
+    "dep:tracing-subscriber",
+    "tokio/signal"
+]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,4 +69,8 @@ pub(crate) enum Mirror {
 #[derive(Debug, Args)]
 pub(crate) struct RunMirror {
     pub(crate) sqlite_db: String,
+
+    /// If provided, the mirror will expose the same API as plc.directory on this address.
+    #[arg(short, long)]
+    pub(crate) listen: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,7 @@ pub(crate) struct AuditOps {
 #[derive(Debug, Subcommand)]
 pub(crate) enum Mirror {
     Run(RunMirror),
+    Audit(AuditMirror),
 }
 
 /// Runs a mirror of the PLC registry.
@@ -73,4 +74,11 @@ pub(crate) struct RunMirror {
     /// If provided, the mirror will expose the same API as plc.directory on this address.
     #[arg(short, long)]
     pub(crate) listen: Option<String>,
+}
+
+/// Audits the contents of the given PLC registry mirror.
+#[cfg(feature = "mirror")]
+#[derive(Debug, Args)]
+pub(crate) struct AuditMirror {
+    pub(crate) sqlite_db: String,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,9 @@ pub(crate) enum Command {
     List(List),
     #[command(subcommand)]
     Ops(Ops),
+    #[cfg(feature = "mirror")]
+    #[command(subcommand)]
+    Mirror(Mirror),
 }
 
 /// Manage authentication
@@ -52,4 +55,18 @@ pub(crate) struct ListOps {
 #[derive(Debug, Args)]
 pub(crate) struct AuditOps {
     pub(crate) user: String,
+}
+
+/// Operate a mirror of the PLC registry.
+#[cfg(feature = "mirror")]
+#[derive(Debug, Subcommand)]
+pub(crate) enum Mirror {
+    Run(RunMirror),
+}
+
+/// Runs a mirror of the PLC registry.
+#[cfg(feature = "mirror")]
+#[derive(Debug, Args)]
+pub(crate) struct RunMirror {
+    pub(crate) sqlite_db: String,
 }

--- a/src/commands/mirror.rs
+++ b/src/commands/mirror.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use tracing::{error, info};
+
+use crate::{cli::RunMirror, mirror, remote::plc};
+
+impl RunMirror {
+    pub(crate) async fn run(&self) -> anyhow::Result<()> {
+        tracing_subscriber::fmt::init();
+
+        let client = reqwest::Client::builder()
+            .user_agent("plc mirror")
+            .build()?;
+
+        // Open the database, initializing it if necessary.
+        let db_handle = mirror::Db::open(&self.sqlite_db, false).await?;
+
+        // Get the most recent entry in the database.
+        let mut after = db_handle.get_last_created().await?;
+
+        // Spawn the importer.
+        let db = db_handle.clone();
+        tokio::spawn(async move {
+            loop {
+                let imported = match plc::export(after.as_ref(), &client).await {
+                    Err(e) => {
+                        error!("Failed to export entries from PLC registry: {:?}", e);
+                        0
+                    }
+                    Ok(entries) => match db.import(entries).await {
+                        Ok(None) => 0,
+                        Ok(Some((last_created_at, imported))) => {
+                            after = Some(last_created_at);
+                            imported
+                        }
+                        Err(e) => {
+                            error!("Failed to import entries: {}", e);
+                            break;
+                        }
+                    },
+                };
+
+                if imported < 1000 {
+                    // We've caught up.
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                }
+            }
+        });
+
+        // Wait for exit.
+        tokio::signal::ctrl_c().await?;
+
+        info!("Shutting down PLC mirror");
+        db_handle.close().await?;
+
+        Ok(())
+    }
+}

--- a/src/commands/mirror.rs
+++ b/src/commands/mirror.rs
@@ -1,8 +1,16 @@
-use std::time::Duration;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
-use tracing::{error, info};
+use tokio::sync::oneshot;
+use tracing::{debug, error, info};
 
-use crate::{cli::RunMirror, mirror, remote::plc};
+use crate::{
+    cli::{AuditMirror, RunMirror},
+    mirror,
+    remote::plc::{self, AuditLog},
+};
 
 impl RunMirror {
     pub(crate) async fn run(self) -> anyhow::Result<()> {
@@ -61,6 +69,126 @@ impl RunMirror {
         tokio::signal::ctrl_c().await?;
 
         info!("Shutting down PLC mirror");
+        db_handle.close().await?;
+
+        Ok(())
+    }
+}
+
+impl AuditMirror {
+    pub(crate) async fn run(self) -> anyhow::Result<()> {
+        tracing_subscriber::fmt::init();
+
+        let chunks = thread::available_parallelism()?.get();
+
+        let (finished_tx, finished_rx) = oneshot::channel();
+
+        // Open the database.
+        let db_handle = mirror::Db::open(&self.sqlite_db, true).await?;
+
+        // Spawn the auditor.
+        let db = db_handle.clone();
+        tokio::spawn(async move {
+            let mut progress_report_time = Instant::now();
+
+            let mut auditing = vec![];
+            let mut total_audited = 0;
+            let mut after = None;
+            loop {
+                let total_dids = match db.total_dids().await {
+                    Ok(total_dids) => total_dids,
+                    Err(e) => {
+                        error!("Failed to count DIDs: {e}");
+                        return;
+                    }
+                };
+
+                while auditing.len() < chunks {
+                    match db.list_dids(10_000, after).await {
+                        Ok(dids) if dids.is_empty() => break,
+                        Ok(dids) => {
+                            after = Some(dids.last().as_ref().expect("non-empty").0);
+
+                            let db = db.clone();
+                            auditing.push(tokio::spawn(async move {
+                                let audited = dids.len();
+                                for (id, did) in dids {
+                                    match db.get_audit_log(did.clone()).await {
+                                        Ok(entries) => {
+                                            let audit_log = AuditLog::new(did.clone(), entries);
+
+                                            match audit_log.validate() {
+                                                Ok(()) => {
+                                                    debug!(
+                                                        "[{id}] Audit log for {} is valid!",
+                                                        did.as_ref()
+                                                    )
+                                                }
+                                                Err(errors) => {
+                                                    error!(
+                                                        "[{id}] Audit log for {} is invalid:",
+                                                        did.as_ref()
+                                                    );
+                                                    for e in errors {
+                                                        error!("- {}", e);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Err(e)
+                                            if e.to_string()
+                                                == "connection to sqlite database closed" =>
+                                        {
+                                            return None;
+                                        }
+                                        Err(e) => error!(
+                                            "[{id}] Failed to get audit log for {}: {e}",
+                                            did.as_ref()
+                                        ),
+                                    }
+                                }
+                                Some(audited)
+                            }));
+                        }
+                        Err(e) if e.to_string() == "connection to sqlite database closed" => {
+                            return;
+                        }
+                        Err(e) => {
+                            error!("Failed to list DIDs after {:?}: {e}", after);
+                            return;
+                        }
+                    }
+                }
+
+                if auditing.is_empty() {
+                    info!("Finished auditing mirror");
+                    let _ = finished_tx.send(());
+                    return;
+                }
+
+                let (res, _, remaining) = futures_util::future::select_all(auditing).await;
+                if let Ok(Some(audited)) = res {
+                    total_audited += audited;
+                }
+                auditing = remaining;
+
+                if Instant::now() >= progress_report_time {
+                    let progress = (total_audited * 100) as f64 / total_dids as f64;
+                    info!(
+                        "Audit progress: {:0.1}% ({total_audited}/{total_dids})",
+                        progress,
+                    );
+                    progress_report_time += Duration::from_secs(60);
+                }
+            }
+        });
+
+        // Wait for exit.
+        tokio::select! {
+            _ = finished_rx => (),
+            _ = tokio::signal::ctrl_c() => (),
+        }
+
         db_handle.close().await?;
 
         Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,6 @@
 mod auth;
 mod list;
 mod ops;
+
+#[cfg(feature = "mirror")]
+mod mirror;

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,10 @@ use crate::{
     remote::{handle, plc},
 };
 
+pub(crate) const ATPROTO_VERIFICATION_METHOD: &str = "atproto";
+pub(crate) const ATPROTO_PDS_KIND: &str = "atproto_pds";
+pub(crate) const ATPROTO_PDS_TYPE: &str = "AtprotoPersonalDataServer";
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct State {
@@ -81,7 +85,10 @@ impl State {
 
     pub(crate) fn signing_key(&self) -> Option<atrium_crypto::Result<Key>> {
         // Ignore non-ATProto verification methods.
-        self.plc.verification_methods.get("atproto").map(Key::did)
+        self.plc
+            .verification_methods
+            .get(ATPROTO_VERIFICATION_METHOD)
+            .map(Key::did)
     }
 
     pub(crate) fn rotation_keys(&self) -> Vec<atrium_crypto::Result<Key>> {
@@ -92,8 +99,8 @@ impl State {
     pub(crate) fn endpoint(&self) -> Option<&str> {
         self.plc
             .services
-            .get("atproto_pds")
-            .and_then(|v| (v.r#type == "AtprotoPersonalDataServer").then_some(v.endpoint.as_str()))
+            .get(ATPROTO_PDS_KIND)
+            .and_then(|v| (v.r#type == ATPROTO_PDS_TYPE).then_some(v.endpoint.as_str()))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub(crate) enum Error {
             atrium_api::com::atproto::identity::get_recommended_did_credentials::Error,
         >,
     ),
-    PlcDirectoryRequestFailed,
+    PlcDirectoryRequestFailed(reqwest::Error),
     PlcDirectoryReturnedInvalidAuditLog,
     PlcDirectoryReturnedInvalidDidDocument,
     #[cfg(feature = "mirror")]
@@ -44,8 +44,8 @@ impl fmt::Debug for Error {
             Error::PdsAuthFailed(e) => write!(f, "Failed to authenticate to PDS: {}", e),
             Error::PdsAuthRefreshFailed(e) => write!(f, "Failed to refresh PDS session: {}", e),
             Error::PdsServerKeyLookupFailed(e) => write!(f, "Lookup of PDS server keys failed: {}", e),
-            Error::PlcDirectoryRequestFailed => {
-                write!(f, "An error occurred while talking to plc.directory")
+            Error::PlcDirectoryRequestFailed(e) => {
+                write!(f, "An error occurred while talking to plc.directory: {e}")
             }
             Error::PlcDirectoryReturnedInvalidAuditLog => {
                 write!(f, "plc.directory returned an invalid audit log")

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,9 +21,13 @@ pub(crate) enum Error {
     PlcDirectoryRequestFailed,
     PlcDirectoryReturnedInvalidAuditLog,
     PlcDirectoryReturnedInvalidDidDocument,
+    #[cfg(feature = "mirror")]
+    PlcDirectoryReturnedInvalidLogEntries,
     PlcDirectoryReturnedInvalidOperationLog,
     SessionSaveFailed,
     UnsupportedDidMethod(String),
+    #[cfg(feature = "mirror")]
+    Mirror(anyhow::Error),
 }
 
 // Rust only supports `fn main() -> Result<(), E: Debug>`, so we implement `Debug`
@@ -49,11 +53,17 @@ impl fmt::Debug for Error {
             Error::PlcDirectoryReturnedInvalidDidDocument => {
                 write!(f, "plc.directory returned an invalid DID document")
             }
+            #[cfg(feature = "mirror")]
+            Error::PlcDirectoryReturnedInvalidLogEntries => {
+                write!(f, "plc.directory returned invalid log entries")
+            }
             Error::PlcDirectoryReturnedInvalidOperationLog => {
                 write!(f, "plc.directory returned an invalid operation log")
             }
             Error::SessionSaveFailed => write!(f, "Failed to save PDS session data"),
             Error::UnsupportedDidMethod(method) => write!(f, "Unsupported DID method {}; this tool only works with did:plc identities", method),
+            #[cfg(feature = "mirror")]
+            Error::Mirror(e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ mod local;
 mod remote;
 mod util;
 
+#[cfg(feature = "mirror")]
+mod mirror;
+
 #[tokio::main]
 async fn main() -> Result<(), error::Error> {
     let opts = cli::Options::parse();
@@ -17,5 +20,9 @@ async fn main() -> Result<(), error::Error> {
         cli::Command::List(command) => command.run().await,
         cli::Command::Ops(cli::Ops::List(command)) => command.run().await,
         cli::Command::Ops(cli::Ops::Audit(command)) => command.run().await,
+        #[cfg(feature = "mirror")]
+        cli::Command::Mirror(cli::Mirror::Run(command)) => {
+            command.run().await.map_err(error::Error::Mirror)
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,10 @@ async fn main() -> Result<(), error::Error> {
         cli::Command::Ops(cli::Ops::List(command)) => command.run().await,
         cli::Command::Ops(cli::Ops::Audit(command)) => command.run().await,
         #[cfg(feature = "mirror")]
-        cli::Command::Mirror(cli::Mirror::Run(command)) => {
-            command.run().await.map_err(error::Error::Mirror)
+        cli::Command::Mirror(command) => match command {
+            cli::Mirror::Run(command) => command.run().await,
+            cli::Mirror::Audit(command) => command.run().await,
         }
+        .map_err(error::Error::Mirror),
     }
 }

--- a/src/mirror/api.rs
+++ b/src/mirror/api.rs
@@ -1,0 +1,253 @@
+use std::fmt;
+
+use anyhow::anyhow;
+use atrium_api::{did_doc::DidDocument, types::string::Did};
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderValue, Response},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use bytes::{BufMut, BytesMut};
+use reqwest::{header, StatusCode};
+use serde::Serialize;
+use tokio::net::TcpListener;
+
+use super::{Db, ExportParams};
+use crate::remote::plc::{LogEntry, SignedOperation};
+
+pub(crate) async fn serve(db: Db, addr: String) -> anyhow::Result<()> {
+    let app = Router::new()
+        .route("/:did", get(resolve_did))
+        .route("/:did/log", get(get_plc_op_log))
+        .route("/:did/log/audit", get(get_plc_audit_log))
+        .route("/:did/log/last", get(get_last_op))
+        .route("/:did/data", get(get_plc_data))
+        .route("/export", get(export))
+        .with_state(db);
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn resolve_did(Path(did): Path<Did>, State(db): State<Db>) -> impl IntoResponse {
+    let mut status = StatusCode::OK;
+
+    let mut response = Json(PlcResult::from(
+        db.get_last_active_entry(did.clone())
+            .await
+            .and_then(|entry| {
+                entry
+                    .ok_or_else(|| {
+                        status = StatusCode::NOT_FOUND;
+                        anyhow!("DID not registered: {}", did.as_ref())
+                    })?
+                    .into_state()
+                    .ok_or_else(|| {
+                        status = StatusCode::GONE;
+                        anyhow!("DID not available: {}", did.as_ref())
+                    })
+            })
+            .and_then(|state| {
+                state.into_doc().map(DidDocWithContext::new).map_err(|()| {
+                    anyhow!(
+                        "Verification methods for DID are corrupted: {}",
+                        did.as_ref()
+                    )
+                })
+            }),
+    ))
+    .into_response();
+
+    *response.status_mut() = status;
+    *response
+        .headers_mut()
+        .get_mut(header::CONTENT_TYPE)
+        .expect("Json sets this") = HeaderValue::from_static("application/did+ld+json");
+
+    response
+}
+
+async fn get_plc_op_log(
+    Path(did): Path<Did>,
+    State(db): State<Db>,
+) -> (StatusCode, Json<PlcResult<Vec<SignedOperation>>>) {
+    let mut status = StatusCode::OK;
+
+    let response = Json(
+        db.get_audit_log(did.clone())
+            .await
+            .and_then(|entries| {
+                if entries.is_empty() {
+                    status = StatusCode::NOT_FOUND;
+                    Err(anyhow!("DID not registered: {}", did.as_ref()))
+                } else {
+                    Ok(entries.into_iter().map(|entry| entry.operation).collect())
+                }
+            })
+            .into(),
+    );
+
+    (status, response)
+}
+
+async fn get_plc_audit_log(
+    Path(did): Path<Did>,
+    State(db): State<Db>,
+) -> (StatusCode, Json<PlcResult<Vec<LogEntry>>>) {
+    let mut status = StatusCode::OK;
+
+    let response = Json(
+        db.get_audit_log(did.clone())
+            .await
+            .and_then(|entries| {
+                if entries.is_empty() {
+                    status = StatusCode::NOT_FOUND;
+                    Err(anyhow!("DID not registered: {}", did.as_ref()))
+                } else {
+                    Ok(entries)
+                }
+            })
+            .into(),
+    );
+
+    (status, response)
+}
+
+async fn get_last_op(
+    Path(did): Path<Did>,
+    State(db): State<Db>,
+) -> (StatusCode, Json<PlcResult<SignedOperation>>) {
+    let mut status = StatusCode::OK;
+
+    let response = Json(
+        db.get_last_active_entry(did.clone())
+            .await
+            .and_then(|entry| {
+                entry.ok_or_else(|| {
+                    status = StatusCode::NOT_FOUND;
+                    anyhow!("DID not registered: {}", did.as_ref())
+                })
+            })
+            .map(|entry| entry.operation)
+            .into(),
+    );
+
+    (status, response)
+}
+
+async fn get_plc_data(
+    Path(did): Path<Did>,
+    State(db): State<Db>,
+) -> (StatusCode, Json<PlcResult<crate::data::State>>) {
+    let mut status = StatusCode::OK;
+
+    let response = Json(
+        db.get_last_active_entry(did.clone())
+            .await
+            .and_then(|entry| {
+                entry
+                    .ok_or_else(|| {
+                        status = StatusCode::NOT_FOUND;
+                        anyhow!("DID not registered: {}", did.as_ref())
+                    })?
+                    .into_state()
+                    .ok_or_else(|| {
+                        status = StatusCode::GONE;
+                        anyhow!("DID not available: {}", did.as_ref())
+                    })
+            })
+            .into(),
+    );
+
+    (status, response)
+}
+
+async fn export(Query(params): Query<ExportParams>, State(db): State<Db>) -> JsonLines<LogEntry> {
+    JsonLines(PlcResult::from(db.export(params).await))
+}
+
+#[derive(Serialize)]
+struct DidDocWithContext {
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+    #[serde(flatten)]
+    doc: DidDocument,
+}
+
+impl DidDocWithContext {
+    fn new(doc: DidDocument) -> Self {
+        Self {
+            context: vec![
+                "https://www.w3.org/ns/did/v1".into(),
+                "https://w3id.org/security/multikey/v1".into(),
+                "https://w3id.org/security/suites/secp256k1-2019/v1".into(),
+            ],
+            doc,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum PlcResult<T> {
+    Ok(T),
+    Err { message: String },
+}
+
+impl<T, E: fmt::Display> From<Result<T, E>> for PlcResult<T> {
+    fn from(value: Result<T, E>) -> Self {
+        match value {
+            Ok(v) => PlcResult::Ok(v),
+            Err(e) => PlcResult::Err {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+struct JsonLines<T>(PlcResult<Vec<T>>);
+
+impl<T> IntoResponse for JsonLines<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response<axum::body::Body> {
+        let write_output = |items: Vec<_>| -> std::io::Result<_> {
+            // Use a small initial capacity of 128 bytes like serde_json::to_vec
+            // https://docs.rs/serde_json/1.0.82/src/serde_json/ser.rs.html#2189
+            let mut buf = BytesMut::with_capacity(128).writer();
+            let mut writer = serde_jsonlines::JsonLinesWriter::new(&mut buf);
+            writer.write_all(&items)?;
+            writer.flush()?;
+            Ok(buf)
+        };
+
+        match self.0 {
+            PlcResult::Ok(items) => match write_output(items) {
+                Ok(buf) => (
+                    [(
+                        header::CONTENT_TYPE,
+                        // This is not specified anywhere, but it's what plc.directory uses.
+                        HeaderValue::from_static("application/jsonlines"),
+                    )],
+                    buf.into_inner().freeze(),
+                )
+                    .into_response(),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                    )],
+                    err.to_string(),
+                )
+                    .into_response(),
+            },
+            err => (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response(),
+        }
+    }
+}

--- a/src/mirror/db.rs
+++ b/src/mirror/db.rs
@@ -1,0 +1,454 @@
+use async_sqlite::{
+    rusqlite::{named_params, CachedStatement, OpenFlags, OptionalExtension, Transaction},
+    JournalMode, Pool, PoolBuilder,
+};
+use atrium_api::types::string::{Cid, Datetime, Did};
+use tracing::info;
+
+use crate::{
+    data::{ATPROTO_PDS_KIND, ATPROTO_PDS_TYPE, ATPROTO_VERIFICATION_METHOD},
+    remote::plc,
+};
+
+#[derive(Clone)]
+pub(crate) struct Db {
+    inner: Pool,
+}
+
+impl Db {
+    pub(crate) async fn open(path: &str, read_only: bool) -> anyhow::Result<Self> {
+        let inner = PoolBuilder::new()
+            .path(path)
+            .flags(if read_only {
+                OpenFlags::SQLITE_OPEN_READ_ONLY
+                    | OpenFlags::SQLITE_OPEN_URI
+                    | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            } else {
+                OpenFlags::default()
+            })
+            .journal_mode(JournalMode::Wal)
+            .open()
+            .await?;
+
+        if !read_only {
+            // Ensure the necessary tables exist.
+            inner
+                .conn_mut(|conn| {
+                    let tx = conn.transaction()?;
+                    tx.execute_batch(CREATE_DATABASES)?;
+                    tx.commit()
+                })
+                .await?;
+        }
+
+        Ok(Self { inner })
+    }
+
+    pub(crate) async fn close(self) -> anyhow::Result<()> {
+        Ok(self.inner.close().await?)
+    }
+
+    pub(crate) async fn get_last_created(&self) -> anyhow::Result<Option<Datetime>> {
+        let created_at = self
+            .inner
+            .conn(|conn| {
+                conn.query_row(
+                    "SELECT created_at
+                    FROM plc_log
+                    ORDER BY created_at DESC
+                    LIMIT 1",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+            })
+            .await?;
+
+        Ok(created_at.map(|s| s.parse()).transpose()?)
+    }
+
+    pub(crate) async fn import(
+        &self,
+        entries: Vec<plc::LogEntry>,
+    ) -> anyhow::Result<Option<(Datetime, usize)>> {
+        info!("Importing {} entries", entries.len());
+
+        Ok(self
+            .inner
+            .conn_mut(|conn| {
+                let mut latest_created_at = None;
+                let imported = entries.len();
+
+                let tx = conn.transaction()?;
+
+                {
+                    let mut db = DbInserter::new(&tx)?;
+
+                    for entry in entries {
+                        let identity_id = db.insert_did(entry.did)?;
+
+                        match entry.operation.content {
+                            plc::Operation::Change(op) => {
+                                let atproto_signing = op
+                                    .data
+                                    .verification_methods
+                                    .iter()
+                                    .find(|(method, _)| *method == ATPROTO_VERIFICATION_METHOD)
+                                    .map(|(_, key)| db.insert_key(key))
+                                    .transpose()?;
+
+                                let atproto_pds = op
+                                    .data
+                                    .services
+                                    .iter()
+                                    .find(|(kind, service)| {
+                                        // A couple of DIDs exist that use `atproto_pds`
+                                        // with `atprotoPersonalDataServer` instead of the
+                                        // correct capitalization. We have to leave these
+                                        // stored in `verification_methods` in order for
+                                        // the operation to be canonically readable.
+                                        *kind == ATPROTO_PDS_KIND
+                                            && service.r#type == ATPROTO_PDS_TYPE
+                                    })
+                                    .map(|(_, service)| db.insert_atproto_pds(&service.endpoint))
+                                    .transpose()?;
+
+                                let entry_id = db.insert_entry(
+                                    entry.cid,
+                                    identity_id,
+                                    entry.created_at.as_str(),
+                                    entry.nullified,
+                                    "O",
+                                    Some(op.data.also_known_as),
+                                    atproto_signing,
+                                    atproto_pds,
+                                    op.prev,
+                                    &entry.operation.sig,
+                                )?;
+
+                                for (authority, key) in op.data.rotation_keys.iter().enumerate() {
+                                    db.insert_rotation_key(entry_id, authority, key)?;
+                                }
+
+                                for (service, key) in
+                                    op.data.verification_methods.into_iter().filter(
+                                        |(method, _)| *method != ATPROTO_VERIFICATION_METHOD,
+                                    )
+                                {
+                                    db.insert_verification_method(entry_id, &service, &key)?;
+                                }
+
+                                for (kind, service) in
+                                    op.data.services.into_iter().filter(|(kind, service)| {
+                                        !(*kind == ATPROTO_PDS_KIND
+                                            && service.r#type == ATPROTO_PDS_TYPE)
+                                    })
+                                {
+                                    db.insert_service(
+                                        entry_id,
+                                        &kind,
+                                        &service.r#type,
+                                        &service.endpoint,
+                                    )?;
+                                }
+                            }
+                            plc::Operation::Tombstone(op) => {
+                                db.insert_entry(
+                                    entry.cid,
+                                    identity_id,
+                                    entry.created_at.as_str(),
+                                    entry.nullified,
+                                    "T",
+                                    None,
+                                    None,
+                                    None,
+                                    Some(op.prev),
+                                    &entry.operation.sig,
+                                )?;
+                            }
+                            plc::Operation::LegacyCreate(op) => {
+                                let atproto_signing = db.insert_key(&op.signing_key)?;
+                                let atproto_pds = db.insert_atproto_pds(&op.service)?;
+
+                                let entry_id = db.insert_entry(
+                                    entry.cid,
+                                    identity_id,
+                                    entry.created_at.as_str(),
+                                    entry.nullified,
+                                    "C",
+                                    Some(vec![format!("at://{}", op.handle)]),
+                                    Some(atproto_signing),
+                                    Some(atproto_pds),
+                                    None,
+                                    &entry.operation.sig,
+                                )?;
+
+                                db.insert_rotation_key(entry_id, 0, &op.recovery_key)?;
+                                db.insert_rotation_key(entry_id, 1, &op.signing_key)?;
+                            }
+                        }
+
+                        latest_created_at = Some(entry.created_at);
+                    }
+                }
+
+                tx.commit()?;
+
+                if let Some(latest_created_at) = latest_created_at {
+                    Ok(Some((latest_created_at, imported)))
+                } else {
+                    assert_eq!(imported, 0);
+                    Ok(None)
+                }
+            })
+            .await?)
+    }
+}
+
+const CREATE_DATABASES: &str = "
+CREATE TABLE IF NOT EXISTS identity (
+    identity_id INTEGER PRIMARY KEY,
+    did TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS key (
+    key_id INTEGER PRIMARY KEY,
+    key TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS atproto_pds (
+    pds_id INTEGER PRIMARY KEY,
+    endpoint TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS plc_log (
+    entry_id INTEGER PRIMARY KEY,
+    cid BLOB NOT NULL UNIQUE,
+    identity INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    nullified INTEGER,
+    -- operation
+    type TEXT NOT NULL CHECK(type IN ('O','T','C')),
+    also_known_as JSON,
+    atproto_signing INTEGER,
+    atproto_pds INTEGER,
+    prev INTEGER,
+    -- Signatures are stored in their Base64 encoding because
+    -- the log contains signatures with invalid padding.
+    sig TEXT NOT NULL,
+    FOREIGN KEY(identity) REFERENCES identity(identity_id),
+    FOREIGN KEY(atproto_signing) REFERENCES key(key_id)
+    FOREIGN KEY(atproto_pds) REFERENCES atproto_pds(pds_id)
+    FOREIGN KEY(prev) REFERENCES plc_log(entry_id)
+);
+CREATE INDEX IF NOT EXISTS plc_log_idx_created_at ON plc_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS plc_log_idx_identity_created_at ON plc_log(identity, created_at);
+CREATE TABLE IF NOT EXISTS rotation_keys (
+    entry INTEGER NOT NULL,
+    authority INTEGER NOT NULL,
+    key INTEGER NOT NULL,
+    FOREIGN KEY(entry) REFERENCES plc_log(entry_id),
+    FOREIGN KEY(key) REFERENCES key(key_id)
+    CONSTRAINT rotation_keys_set UNIQUE(entry, authority)
+);
+CREATE INDEX IF NOT EXISTS rotation_keys_idx_entry_key ON rotation_keys(entry, key);
+CREATE TABLE IF NOT EXISTS verification_methods (
+    entry INTEGER NOT NULL,
+    service TEXT NOT NULL,
+    key INTEGER NOT NULL,
+    FOREIGN KEY(entry) REFERENCES plc_log(entry_id),
+    FOREIGN KEY(key) REFERENCES key(key_id),
+    CONSTRAINT verification_methods_map UNIQUE(entry, service)
+);
+CREATE INDEX IF NOT EXISTS verification_methods_idx_entry_key ON verification_methods(entry, key);
+CREATE TABLE IF NOT EXISTS services (
+    entry INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    type TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    FOREIGN KEY(entry) REFERENCES plc_log(entry_id),
+    CONSTRAINT services_map UNIQUE(entry, kind)
+);";
+
+struct DbInserter<'a> {
+    stmt_find_entry: CachedStatement<'a>,
+    stmt_insert_did: CachedStatement<'a>,
+    stmt_insert_key: CachedStatement<'a>,
+    stmt_insert_atproto_pds: CachedStatement<'a>,
+    stmt_insert_entry: CachedStatement<'a>,
+    stmt_insert_rotation_key: CachedStatement<'a>,
+    stmt_insert_verification_method: CachedStatement<'a>,
+    stmt_insert_service: CachedStatement<'a>,
+}
+
+impl<'a> DbInserter<'a> {
+    fn new(tx: &'a Transaction) -> async_sqlite::rusqlite::Result<Self> {
+        let stmt_find_entry = tx.prepare_cached(
+            "SELECT entry_id
+            FROM plc_log
+            WHERE cid = :cid",
+        )?;
+
+        let stmt_insert_did = tx.prepare_cached(
+            "INSERT INTO identity(did) VALUES(:did)
+            ON CONFLICT DO UPDATE SET did = did
+            RETURNING identity_id",
+        )?;
+
+        let stmt_insert_key = tx.prepare_cached(
+            "INSERT INTO key(key) VALUES(:key)
+            ON CONFLICT DO UPDATE SET key = key
+            RETURNING key_id",
+        )?;
+
+        let stmt_insert_atproto_pds = tx.prepare_cached(
+            "INSERT INTO atproto_pds(endpoint) VALUES(:endpoint)
+            ON CONFLICT DO UPDATE SET endpoint = endpoint
+            RETURNING pds_id",
+        )?;
+
+        let stmt_insert_entry = tx.prepare_cached(
+            "INSERT INTO plc_log(
+                cid, identity, created_at, nullified,
+                type, also_known_as, atproto_signing, atproto_pds, prev, sig
+            ) VALUES(
+                :cid, :identity, :created_at, :nullified,
+                :type, :also_known_as, :atproto_signing, :atproto_pds, :prev, :sig
+            )
+            ON CONFLICT(cid) DO UPDATE SET cid = cid
+            RETURNING entry_id",
+        )?;
+
+        let stmt_insert_rotation_key = tx.prepare_cached(
+            "INSERT INTO rotation_keys(entry, authority, key)
+            VALUES(:entry, :authority, :key)
+            ON CONFLICT DO NOTHING",
+        )?;
+
+        let stmt_insert_verification_method = tx.prepare_cached(
+            "INSERT INTO verification_methods(entry, service, key)
+            VALUES(:entry, :service, :key)
+            ON CONFLICT DO NOTHING",
+        )?;
+
+        let stmt_insert_service = tx.prepare_cached(
+            "INSERT INTO services(entry, kind, type, endpoint)
+            VALUES(:entry, :kind, :type, :endpoint)
+            ON CONFLICT DO NOTHING",
+        )?;
+
+        Ok(Self {
+            stmt_find_entry,
+            stmt_insert_did,
+            stmt_insert_key,
+            stmt_insert_atproto_pds,
+            stmt_insert_entry,
+            stmt_insert_rotation_key,
+            stmt_insert_verification_method,
+            stmt_insert_service,
+        })
+    }
+
+    fn insert_did(&mut self, did: Did) -> async_sqlite::rusqlite::Result<i64> {
+        self.stmt_insert_did
+            .query_row(named_params! {":did": did.as_ref()}, |row| row.get(0))
+    }
+
+    fn insert_key(&mut self, key: &str) -> async_sqlite::rusqlite::Result<i64> {
+        self.stmt_insert_key
+            .query_row(named_params! {":key": key}, |row| row.get(0))
+    }
+
+    fn insert_atproto_pds(&mut self, endpoint: &str) -> async_sqlite::rusqlite::Result<i64> {
+        self.stmt_insert_atproto_pds
+            .query_row(named_params! {":endpoint": endpoint}, |row| row.get(0))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_entry(
+        &mut self,
+        cid: Cid,
+        identity_id: i64,
+        created_at: &str,
+        nullified: bool,
+        r#type: &str,
+        also_known_as: Option<Vec<String>>,
+        atproto_signing: Option<i64>,
+        atproto_pds: Option<i64>,
+        prev: Option<Cid>,
+        sig: &str,
+    ) -> async_sqlite::rusqlite::Result<i64> {
+        let also_known_as = also_known_as.map(|aka| {
+            serde_json::Value::Array(aka.into_iter().map(serde_json::Value::String).collect())
+        });
+
+        let prev = prev
+            .map(|cid| {
+                self.stmt_find_entry
+                    .query_row(named_params! {":cid": cid.as_ref().to_bytes()}, |row| {
+                        row.get::<_, i64>(0)
+                    })
+            })
+            .transpose()?;
+
+        self.stmt_insert_entry.query_row(
+            named_params! {
+                ":cid": cid.as_ref().to_bytes(),
+                ":identity": identity_id,
+                ":created_at": created_at,
+                ":nullified": nullified,
+                ":type": r#type,
+                ":also_known_as": also_known_as,
+                ":atproto_signing": atproto_signing,
+                ":atproto_pds": atproto_pds,
+                ":prev": prev,
+                ":sig": sig,
+            },
+            |row| row.get(0),
+        )
+    }
+
+    fn insert_rotation_key(
+        &mut self,
+        entry_id: i64,
+        authority: usize,
+        key: &str,
+    ) -> async_sqlite::rusqlite::Result<()> {
+        let key_id = self.insert_key(key)?;
+        self.stmt_insert_rotation_key.execute(named_params! {
+            ":entry": entry_id,
+            ":authority": authority,
+            ":key": key_id,
+        })?;
+        Ok(())
+    }
+
+    fn insert_verification_method(
+        &mut self,
+        entry_id: i64,
+        service: &str,
+        key: &str,
+    ) -> async_sqlite::rusqlite::Result<()> {
+        let key_id = self.insert_key(key)?;
+        self.stmt_insert_verification_method
+            .execute(named_params! {
+                ":entry": entry_id,
+                ":service": service,
+                ":key": key_id,
+            })?;
+        Ok(())
+    }
+
+    fn insert_service(
+        &mut self,
+        entry_id: i64,
+        kind: &str,
+        r#type: &str,
+        endpoint: &str,
+    ) -> async_sqlite::rusqlite::Result<()> {
+        self.stmt_insert_service.execute(named_params! {
+            ":entry": entry_id,
+            ":kind": kind,
+            ":type": r#type,
+            ":endpoint": endpoint,
+        })?;
+        Ok(())
+    }
+}

--- a/src/mirror/mod.rs
+++ b/src/mirror/mod.rs
@@ -1,0 +1,2 @@
+mod db;
+pub(crate) use db::Db;

--- a/src/mirror/mod.rs
+++ b/src/mirror/mod.rs
@@ -1,2 +1,20 @@
+use atrium_api::types::string::Datetime;
+use serde::Deserialize;
+
+mod api;
+pub(crate) use api::serve;
+
 mod db;
 pub(crate) use db::Db;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ExportParams {
+    count: Option<usize>,
+    after: Option<Datetime>,
+}
+
+impl ExportParams {
+    fn bounded_count(&self) -> usize {
+        self.count.unwrap_or(10).min(1000)
+    }
+}

--- a/src/remote/pds.rs
+++ b/src/remote/pds.rs
@@ -8,7 +8,11 @@ use atrium_api::{
 };
 use atrium_xrpc_client::reqwest::ReqwestClient;
 
-use crate::{data::Key, error::Error, local};
+use crate::{
+    data::{Key, ATPROTO_VERIFICATION_METHOD},
+    error::Error,
+    local,
+};
 
 pub(crate) struct Agent {
     inner: Arc<AtpAgent<MemorySessionStore, ReqwestClient>>,
@@ -56,7 +60,7 @@ impl Agent {
             HashMap::<String, String>::try_from_unknown(d)
                 .map_err(ParseError::Data)
                 .and_then(|m| {
-                    m.get("atproto")
+                    m.get(ATPROTO_VERIFICATION_METHOD)
                         .map(|key| Key::did(key).map_err(ParseError::Key))
                         .transpose()
                 })

--- a/src/remote/plc.rs
+++ b/src/remote/plc.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeMap;
+
 use atrium_api::types::string::{Cid, Datetime, Did};
 use cid::multihash::Multihash;
 use diff::Diff;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -184,6 +187,7 @@ impl LogEntry {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct SignedOperation {
     #[serde(flatten)]
     pub(crate) content: Operation,
@@ -239,6 +243,9 @@ pub(crate) struct ChangeOp {
     ///
     /// In DAG-CBOR encoding, the CID is string-encoded, not a binary IPLD "Link".
     pub(crate) prev: Option<Cid>,
+    /// Thanks to @retr0.id for sponsoring this field.
+    #[serde(flatten)]
+    pub(crate) extra_fields: BTreeMap<String, Value>,
 }
 
 impl ChangeOp {

--- a/src/remote/plc.rs
+++ b/src/remote/plc.rs
@@ -28,7 +28,7 @@ pub(crate) async fn get_state(did: &Did, client: &Client) -> Result<State, Error
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .map_err(|_| Error::PlcDirectoryRequestFailed)?;
+        .map_err(Error::PlcDirectoryRequestFailed)?;
 
     resp.json::<State>()
         .await
@@ -41,7 +41,7 @@ pub(crate) async fn get_ops_log(did: &Did, client: &Client) -> Result<Operations
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .map_err(|_| Error::PlcDirectoryRequestFailed)?;
+        .map_err(Error::PlcDirectoryRequestFailed)?;
 
     let ops = resp
         .json()
@@ -57,7 +57,7 @@ pub(crate) async fn get_audit_log(did: &Did, client: &Client) -> Result<AuditLog
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .map_err(|_| Error::PlcDirectoryRequestFailed)?;
+        .map_err(Error::PlcDirectoryRequestFailed)?;
 
     let entries = resp
         .json()
@@ -92,7 +92,7 @@ pub(crate) async fn export(
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .map_err(|_| Error::PlcDirectoryRequestFailed)?;
+        .map_err(Error::PlcDirectoryRequestFailed)?;
 
     let entries = resp
         .text()

--- a/src/remote/plc/audit.rs
+++ b/src/remote/plc/audit.rs
@@ -20,7 +20,7 @@ pub(crate) struct AuditLog {
 }
 
 impl AuditLog {
-    pub(super) fn new(did: Did, entries: Vec<LogEntry>) -> Self {
+    pub(crate) fn new(did: Did, entries: Vec<LogEntry>) -> Self {
         Self { did, entries }
     }
 

--- a/src/remote/plc/testing.rs
+++ b/src/remote/plc/testing.rs
@@ -10,7 +10,7 @@ use rand_core::OsRng;
 
 use super::{AuditLog, ChangeOp, LegacyCreateOp, LogEntry, Operation, SignedOperation};
 use crate::{
-    data::{PlcData, Service},
+    data::{PlcData, Service, ATPROTO_PDS_KIND, ATPROTO_PDS_TYPE, ATPROTO_VERIFICATION_METHOD},
     util::derive_did,
 };
 
@@ -45,7 +45,11 @@ impl Identity {
 
         Self {
             rotation: vec![P256Keypair::create(&mut rng), P256Keypair::create(&mut rng)],
-            signing: iter::once(("atproto".into(), P256Keypair::create(&mut rng))).collect(),
+            signing: iter::once((
+                ATPROTO_VERIFICATION_METHOD.into(),
+                P256Keypair::create(&mut rng),
+            ))
+            .collect(),
         }
     }
 }
@@ -81,9 +85,9 @@ impl TestLog {
                     .collect(),
                 also_known_as: vec!["at://example.com".into()],
                 services: [(
-                    "atproto_pds".into(),
+                    ATPROTO_PDS_KIND.into(),
                     Service {
-                        r#type: "AtprotoPersonalDataServer".into(),
+                        r#type: ATPROTO_PDS_TYPE.into(),
                         endpoint: "https://bsky.social".into(),
                     },
                 )]
@@ -114,8 +118,10 @@ impl TestLog {
         let mut initial_state = Identity::generate();
 
         // For legacy create ops, the signing key is also a rotation key.
-        *initial_state.signing.get_mut("atproto").unwrap() =
-            P256Keypair::import(&initial_state.rotation[1].export()).unwrap();
+        *initial_state
+            .signing
+            .get_mut(ATPROTO_VERIFICATION_METHOD)
+            .unwrap() = P256Keypair::import(&initial_state.rotation[1].export()).unwrap();
 
         let content = Operation::LegacyCreate(LegacyCreateOp {
             signing_key: initial_state.rotation[1].did(),
@@ -491,8 +497,10 @@ impl Update {
             if let Some(new_signing_key) = self.new_signing_key {
                 new_data
                     .verification_methods
-                    .insert("atproto".into(), new_signing_key.did());
-                new_state.signing.insert("atproto".into(), new_signing_key);
+                    .insert(ATPROTO_VERIFICATION_METHOD.into(), new_signing_key.did());
+                new_state
+                    .signing
+                    .insert(ATPROTO_VERIFICATION_METHOD.into(), new_signing_key);
             }
 
             log.state_updates.push((log.entries.len(), new_state));
@@ -515,20 +523,20 @@ impl Update {
 
         match self.new_pds {
             Some(Some(endpoint)) => {
-                if let Some(service) = new_data.services.get_mut("atproto_pds") {
+                if let Some(service) = new_data.services.get_mut(ATPROTO_PDS_KIND) {
                     service.endpoint = endpoint;
                 } else {
                     new_data.services.insert(
-                        "atproto_pds".into(),
+                        ATPROTO_PDS_KIND.into(),
                         Service {
-                            r#type: "AtprotoPersonalDataServer".into(),
+                            r#type: ATPROTO_PDS_TYPE.into(),
                             endpoint,
                         },
                     );
                 }
             }
             Some(None) => {
-                new_data.services.remove("atproto_pds");
+                new_data.services.remove(ATPROTO_PDS_KIND);
             }
             _ => (),
         }
@@ -710,7 +718,10 @@ fn sign_operation(
             add_signature(content, key, sig_kind)
         }
         Some(KeyKind::Signing) => {
-            let key = get_state(log, None).signing.get("atproto").expect("exists");
+            let key = get_state(log, None)
+                .signing
+                .get(ATPROTO_VERIFICATION_METHOD)
+                .expect("exists");
             add_signature(content, key, sig_kind)
         }
     }

--- a/src/remote/plc/testing.rs
+++ b/src/remote/plc/testing.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::iter;
 
 use atrium_api::types::string::{Cid, Datetime, Did};
@@ -95,6 +95,7 @@ impl TestLog {
                 .collect(),
             },
             prev: None,
+            extra_fields: BTreeMap::new(),
         });
 
         let operation = add_signature(
@@ -545,6 +546,7 @@ impl Update {
             Operation::Change(ChangeOp {
                 data: new_data,
                 prev: self.with_prev.unwrap_or(Some(prev_op.cid.clone())),
+                extra_fields: BTreeMap::new(),
             }),
             &log,
             self.signed_with_key,


### PR DESCRIPTION
This is somewhat outside the intended crate bounds of "key management for DID PLC identities", but it's something I want to enable.

Fair warning: this PR will be rebased, and the database format will likely change incompatibly before the PR merges.